### PR TITLE
Upgrade npm run all

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "babel-loader": "^8.0.4",
     "http-proxy-middleware": "^0.19.0",
     "netlify-lambda": "^1.0.1",
-    "npm-run-all": "^4.1.3"
+    "npm-run-all": "^4.1.5"
   }
 }


### PR DESCRIPTION
The upgrade on npm-run-all abandons the event stream package, thus not getting error when pushing to netlify