### PR TITLE
add promise example

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,14 +22,16 @@ class LambdaDemo extends Component {
 
     return (
       <p>
+        <span>{msg}</span><br />
         <button onClick={this.handleClick('hello')}>
           {loading ? 'Loading...' : 'Call Lambda'}
-        </button>
+        </button><br />
         <button onClick={this.handleClick('async-chuck-norris')}>
-          {loading ? 'Loading...' : 'Call Async Lambda'}
+          {loading ? 'Loading...' : 'Call Lambda - Async'}
+        </button><br />
+        <button onClick={this.handleClick('promise-chuck-norris')}>
+          {loading ? 'Loading...' : 'Call Lambda - Promise'}
         </button>
-        <br />
-        <span>{msg}</span>
       </p>
     );
   }

--- a/src/lambda/promise-chuck-norris.js
+++ b/src/lambda/promise-chuck-norris.js
@@ -1,0 +1,28 @@
+// example to have the handler return a promise directly
+// https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/
+
+import fetch from 'node-fetch';
+export async function handler(event, context) {
+  return new Promise((resolve, reject) => {
+    fetch('https://api.chucknorris.io/jokes/random')
+    .then(response => {
+      if (response.ok) { // response.status >= 200 && response.status < 300
+        return response.json();
+      } else {
+        resolve({ statusCode: response.status, body: response.statusText })
+      };
+    })
+    .then(data =>{
+      const response = {
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ msg: data.value })
+      }
+      resolve(response);
+    })
+    .catch(err => {
+      console.log(err)
+      resolve({ statusCode: 500, body: err.message });
+    })
+  });
+}

--- a/src/lambda/promise-chuck-norris.js
+++ b/src/lambda/promise-chuck-norris.js
@@ -2,7 +2,7 @@
 // https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/
 
 import fetch from 'node-fetch';
-export async function handler(event, context) {
+export function handler(event, context) {
   return new Promise((resolve, reject) => {
     fetch('https://api.chucknorris.io/jokes/random')
     .then(response => {


### PR DESCRIPTION
> [With the new Node.js 8.10 runtime, there are new handler types that can be declared with the “async” keyword or can return a promise directly.][1]

For completion, I propose to add the example to return a promise

[1]: https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/

Please make changes as you see fit. 😀
