### PR TITLE
Fix scripts for yarn start. Update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "react-scripts": "^3.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "npm-run-all --parallel start:app start:lambda",
+    "start:app": "react-scripts start",
     "start:lambda": "netlify-lambda serve src/lambda",
     "build": "run-p build:**",
     "build:app": "react-scripts build",
@@ -28,7 +29,7 @@
   ],
   "devDependencies": {
     "@babel/plugin-transform-object-assign": "^7.0.0",
-    "babel-loader": "8.0.4",
+    "babel-loader": "8.0.5",
     "http-proxy-middleware": "^0.19.0",
     "netlify-lambda": "^1.4.5",
     "npm-run-all": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "react-scripts": "^3.0.0"
   },
   "scripts": {
-    "start": "npm-run-all --parallel start:app start:lambda",
-    "start:app": "react-scripts start",
+    "start": "react-scripts start",
     "start:lambda": "netlify-lambda serve src/lambda",
     "build": "run-p build:**",
     "build:app": "react-scripts build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2236,16 +2236,6 @@ babel-jest@24.7.1, babel-jest@^24.7.1:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-loader@8.0.4:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.4.tgz#7bbf20cbe4560629e2e41534147692d3fecbdce6"
-  integrity sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==
-  dependencies:
-    find-cache-dir "^1.0.0"
-    loader-utils "^1.0.2"
-    mkdirp "^0.5.1"
-    util.promisify "^1.0.0"
-
 babel-loader@8.0.5, babel-loader@^8.0.0:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.5.tgz#225322d7509c2157655840bba52e46b6c2f2fe33"
@@ -4423,15 +4413,6 @@ find-cache-dir@^0.1.1:
     commondir "^1.0.1"
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
-
-find-cache-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
-  integrity sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=
-  dependencies:
-    commondir "^1.0.1"
-    make-dir "^1.0.0"
-    pkg-dir "^2.0.0"
 
 find-cache-dir@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I noticed that yarn start was missing from the script in package.json. I've added a script that reflects the current readme.

Also bumped babel-loader to 8.0.5 because it's needed react-scripts 3.0.0.

Thanks!