### PR TITLE
Correct command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can then access your functions directly at `http://localhost:9000/{function_
 While the functions server is still running, open a new terminal tab and run:
 
 ```
-yarn start:app
+yarn start
 ```
 
 This will start the normal create-react-app dev server and open your app at `http://localhost:3000`.


### PR DESCRIPTION
The command in `package.json` is called `start`, so use this name.

Thanks!